### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Curated list of database (NoSQL, Hadoop, Relational) benchmarks and performance comparisons:
+## Curated list of database (NoSQL, Hadoop, Relational) benchmarks and performance comparisons:
 (please annotate and submit a pull request if you have others)
 
 | Databases | Link | Type | Independent | Date |


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
