### PR TITLE
Add Memgraph and Neo4j performance comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 | Databases | Link | Type | Independent | Date |
 | -------------     | ------ | ---------:| -----------:| ---- |
+|Memgraph, Neo4j|[Memgraph vs. Neo4j: A Performance Comparison](https://memgraph.com/blog/memgraph-vs-neo4j-performance-benchmark-comparison)|Custom|N|2022|
 |SequoiaDB, Cassandra, MongoDB|[NoSQL Performance Test](http://www.msrg.org/publications/pdf_files/2014/NoSQLBenchmark-NoSQL_Performance_Test_-_In-Me.pdf)|YCSB|Y|2014|
 |Redshift, Hive, Shark, Imapala, Tez|[Big Data Benchmark](https://amplab.cs.berkeley.edu/benchmark/)|BDB|Y|2014|
 |LevelDB, RocksDB, HyperLevelDB, LMDB, InfluxDB|[Benchmarking LevelDB vs. RocksDB vs. HyperLevelDB vs. LMDB Performance for InfluxDB](http://influxdb.com/blog/2014/06/20/leveldb_vs_rocksdb_vs_hyperleveldb_vs_lmdb_performance.html)|YCSB|N|2014|


### PR DESCRIPTION
Blog post describing performance comparison of Memgraph 2.4 and Neo4j 5.1 community editions. The methodology is linked in the blog post.